### PR TITLE
Add path-tree to benches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ actix-router = "0.2.7"
 regex = "1.5.4"
 route-recognizer = "0.3.0"
 gonzales = "0.0.3-beta"
+path-tree = "0.2.2"
 
 [features]
 default = []

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -166,8 +166,20 @@ fn compare_routers(c: &mut Criterion) {
     }
     group.bench_function("matchit", |b| {
         b.iter(|| {
-            for route in call() {
+            for route in black_box(call()) {
                 black_box(matchit.at(route).unwrap());
+            }
+        });
+    });
+
+    let mut path_tree = path_tree::PathTree::new();
+    for route in register!(colon) {
+        path_tree.insert(route, true);
+    }
+    group.bench_function("path-tree", |b| {
+        b.iter(|| {
+            for route in black_box(call()) {
+                black_box(path_tree.find(route).unwrap());
             }
         });
     });
@@ -175,7 +187,7 @@ fn compare_routers(c: &mut Criterion) {
     let gonzales = gonzales::RouterBuilder::new().build(register!(brackets));
     group.bench_function("gonzales", |b| {
         b.iter(|| {
-            for route in call() {
+            for route in black_box(call()) {
                 black_box(gonzales.route(route).unwrap());
             }
         });
@@ -188,7 +200,7 @@ fn compare_routers(c: &mut Criterion) {
     let actix = actix.finish();
     group.bench_function("actix", |b| {
         b.iter(|| {
-            for route in call() {
+            for route in black_box(call()) {
                 let mut path = actix_router::Path::new(route);
                 black_box(actix.recognize(&mut path).unwrap());
             }
@@ -198,7 +210,7 @@ fn compare_routers(c: &mut Criterion) {
     let regex_set = regex::RegexSet::new(register!(regex)).unwrap();
     group.bench_function("regex", |b| {
         b.iter(|| {
-            for route in call() {
+            for route in black_box(call()) {
                 black_box(regex_set.matches(route));
             }
         });
@@ -210,7 +222,7 @@ fn compare_routers(c: &mut Criterion) {
     }
     group.bench_function("route-recognizer", |b| {
         b.iter(|| {
-            for route in call() {
+            for route in black_box(call()) {
                 black_box(route_recognizer.recognize(route).unwrap());
             }
         });


### PR DESCRIPTION
resolves #14 

```
Compare Routers/matchit time:   [299.53 ns 300.36 ns 301.50 ns]                                    
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) high mild
  7 (7.00%) high severe
Compare Routers/path-tree                                                                             
                        time:   [627.85 ns 628.94 ns 630.44 ns]
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) high mild
  11 (11.00%) high severe
Compare Routers/gonzales                                                                            
                        time:   [299.46 ns 300.60 ns 302.71 ns]
Found 14 outliers among 100 measurements (14.00%)
  5 (5.00%) high mild
  9 (9.00%) high severe
Compare Routers/actix   time:   [40.940 us 41.025 us 41.163 us]                                   
Found 15 outliers among 100 measurements (15.00%)
  5 (5.00%) high mild
  10 (10.00%) high severe
Compare Routers/regex   time:   [41.405 us 41.573 us 41.892 us]                                   
Found 16 outliers among 100 measurements (16.00%)
  4 (4.00%) high mild
  12 (12.00%) high severe
Compare Routers/route-recognizer                                                                             
                        time:   [5.6700 us 5.6891 us 5.7226 us]
Found 13 outliers among 100 measurements (13.00%)
  6 (6.00%) high mild
  7 (7.00%) high severe
```