### PR TITLE
Allow overlapping static and catchall routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,15 @@ assert!(m.at("/users").is_err());
 
 ### Catch-all Parameters
 
-Catch-all parameters start with `*` and match everything, including slashes. They must always be at the **end** of the route:
+Catch-all parameters start with `*` and match everything after the `/`. They must always be at the **end** of the route:
 
 ```rust,ignore
 let mut m = Router::new();
 m.insert("/*p", true)?;
 
-assert_eq!(m.at("/")?.params.get("p"), Some("/"));
-assert_eq!(m.at("/foo.js")?.params.get("p"), Some("/foo.js"));
-assert_eq!(m.at("/c/bar.css")?.params.get("p"), Some("/c/bar.css"));
+assert_eq!(m.at("/")?.params.get("p"), Some(""));
+assert_eq!(m.at("/foo.js")?.params.get("p"), Some("foo.js"));
+assert_eq!(m.at("/c/bar.css")?.params.get("p"), Some("c/bar.css"));
 ```
 
 ## Routing Priority
@@ -59,23 +59,9 @@ assert_eq!(m.at("/c/bar.css")?.params.get("p"), Some("/c/bar.css"));
 Static and dynamic route segments are allowed to overlap. If they do, static segments will be given higher priority:
 ```rust,ignore
 let mut m = Router::new();
-m.insert("/home", "Welcome!").unwrap();  // priority: 1
+m.insert("/", "Welcome!").unwrap();      // priority: 1
 m.insert("/about", "About Me").unwrap(); // priority: 1
-m.insert("/:other", "...").unwrap();     // priority: 2
-```
-
-Note that *catch-all* parameters are not allowed to overlap with other path segments. Attempting to insert a conflicting route will result
-in an error:
-```rust,ignore
-let mut m = Router::new();
-m.insert("/home", "Welcome!").unwrap();
-
-assert_eq!(
-    m.insert("/*filepath", "..."),
-    Err(InsertError::Conflict {
-        with: "/home".into()
-    })
-);
+m.insert("/*filepath", "...").unwrap();  // priority: 2
 ```
 
 ## How does it work?

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,8 +17,6 @@ pub enum InsertError {
     UnnamedParam,
     /// Catch-all parameters are only allowed at the end of a path.
     InvalidCatchAll,
-    /// Invalid tokens in the inserted path.
-    MalformedPath,
 }
 
 impl fmt::Display for InsertError {
@@ -37,7 +35,6 @@ impl fmt::Display for InsertError {
                 f,
                 "catch-all parameters are only allowed at the end of a route"
             ),
-            Self::MalformedPath => write!(f, "malformed path"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 //!
 //! ### Catch-all Parameters
 //!
-//! Catch-all parameters start with `*` and match everything, including slashes. They must always be at the **end** of the route:
+//! Catch-all parameters start with `*` and match everything after the `/`. They must always be at the **end** of the route:
 //!
 //! ```rust
 //! # use matchit::Router;
@@ -56,9 +56,8 @@
 //! let mut m = Router::new();
 //! m.insert("/*p", true)?;
 //!
-//! assert_eq!(m.at("/")?.params.get("p"), Some("/"));
-//! assert_eq!(m.at("/foo.js")?.params.get("p"), Some("/foo.js"));
-//! assert_eq!(m.at("/c/bar.css")?.params.get("p"), Some("/c/bar.css"));
+//! assert_eq!(m.at("/foo.js")?.params.get("p"), Some("foo.js"));
+//! assert_eq!(m.at("/c/bar.css")?.params.get("p"), Some("c/bar.css"));
 //!
 //! # Ok(())
 //! # }
@@ -66,34 +65,14 @@
 //!
 //! ## Routing Priority
 //!
-//! Static and dynamic route segments are allowed to overlap. If they do, static segments will be given higher priority:
+//! Static and wildcard routes are allowed to overlap. If they do, static segments will be given higher priority:
 //! ```rust
 //! # use matchit::Router;
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let mut m = Router::new();
-//! m.insert("/home", "Welcome!").unwrap();  // priority: 1
+//! m.insert("/", "Welcome!").unwrap()    ;  // priority: 1
 //! m.insert("/about", "About Me").unwrap(); // priority: 1
-//! m.insert("/:other", "...").unwrap();     // priority: 2
-//!
-//! # Ok(())
-//! # }
-//! ```
-//!
-//! Note that *catch-all* parameters are not allowed to overlap with other path segments. Attempting to insert a conflicting route will result
-//! in an error:
-//!
-//! ```rust
-//! # use matchit::{InsertError, Router};
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! let mut m = Router::new();
-//! m.insert("/home", "Welcome!").unwrap();
-//!
-//! assert_eq!(
-//!     m.insert("/*filepath", "..."),
-//!     Err(InsertError::Conflict {
-//!         with: "/home".into()
-//!     })
-//! );
+//! m.insert("/*filepath", "...").unwrap();  // priority: 2
 //!
 //! # Ok(())
 //! # }

--- a/src/router.rs
+++ b/src/router.rs
@@ -5,6 +5,7 @@ use crate::{InsertError, MatchError, Params};
 ///
 /// See [the crate documentation](crate) for details.
 #[derive(Clone)]
+#[cfg_attr(test, derive(Debug))]
 pub struct Router<T> {
     root: Node<T>,
 }


### PR DESCRIPTION
- routes like `/*foo` and `/bar` are now allowed to overlap, with `/bar` prioritized (#18)
- the route `/foo/` no longer matches `/foo/*bar`, and is allowed to exist on it's own
- route parameters for catchall routes no longer include the `/`, e.g. `/foo.js` will match `/*filepath` with a value of `foo.js`, not `/foo.js`
- `Error::MalformedPath` was removed in favor of `Error::InvalidCatchAll`