### PR TITLE
Normalize Route Parameters

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use crate::tree::{denormalize_prefix, Node};
+use crate::tree::{denormalize_params, Node};
 
 use std::fmt;
 
@@ -46,14 +46,21 @@ impl InsertError {
         let mut route = route[..route.len() - prefix.len()].to_owned();
 
         if !route.ends_with(&current.prefix) {
-            route.extend_from_slice(denormalize_prefix(&current));
+            route.extend_from_slice(&current.prefix);
+        }
+
+        let mut last = current;
+        while let Some(node) = last.children.first() {
+            last = node;
         }
 
         let mut current = current.children.first();
         while let Some(node) = current {
-            route.extend_from_slice(denormalize_prefix(&node));
+            route.extend_from_slice(&node.prefix);
             current = node.children.first();
         }
+
+        denormalize_params(&mut route, &last.param_remapping);
 
         InsertError::Conflict {
             with: String::from_utf8(route).unwrap(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use crate::tree::Node;
+use crate::tree::{denormalize_prefix, Node};
 
 use std::fmt;
 
@@ -46,12 +46,12 @@ impl InsertError {
         let mut route = route[..route.len() - prefix.len()].to_owned();
 
         if !route.ends_with(&current.prefix) {
-            route.extend_from_slice(&current.prefix);
+            route.extend_from_slice(denormalize_prefix(&current));
         }
 
         let mut current = current.children.first();
         while let Some(node) = current {
-            route.extend_from_slice(&node.prefix);
+            route.extend_from_slice(denormalize_prefix(&node));
             current = node.children.first();
         }
 

--- a/src/params.rs
+++ b/src/params.rs
@@ -139,6 +139,24 @@ impl<'k, 'v> Params<'k, 'v> {
             ParamsKind::Large(vec) => vec.push(param),
         }
     }
+
+    // Transform each key.
+    pub(crate) fn for_each_key_mut(&mut self, f: impl Fn((usize, &mut &'k [u8]))) {
+        match &mut self.kind {
+            ParamsKind::None => {}
+            ParamsKind::Small(arr, len) => arr
+                .iter_mut()
+                .take(*len)
+                .map(|param| &mut param.key)
+                .enumerate()
+                .for_each(f),
+            ParamsKind::Large(vec) => vec
+                .iter_mut()
+                .map(|param| &mut param.key)
+                .enumerate()
+                .for_each(f),
+        }
+    }
 }
 
 /// An iterator over the keys and values of a route's [parameters](crate::Params).

--- a/src/router.rs
+++ b/src/router.rs
@@ -7,7 +7,7 @@ use crate::{InsertError, MatchError, Params};
 #[derive(Clone)]
 #[cfg_attr(test, derive(Debug))]
 pub struct Router<T> {
-    pub root: Node<T>,
+    root: Node<T>,
 }
 
 impl<T> Default for Router<T> {

--- a/src/router.rs
+++ b/src/router.rs
@@ -7,7 +7,7 @@ use crate::{InsertError, MatchError, Params};
 #[derive(Clone)]
 #[cfg_attr(test, derive(Debug))]
 pub struct Router<T> {
-    root: Node<T>,
+    pub root: Node<T>,
 }
 
 impl<T> Default for Router<T> {


### PR DESCRIPTION
Resolves https://github.com/ibraheemdev/matchit/issues/13.

Route parameters are now normalized when inserted, and a remapping of parameter names is stored at the leaf node holding the value. This way we know what parameter names are expected after a successful match, and can apply the remappings.