### PR TITLE
Support escaping '{' and '}'

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.56
+          toolchain: 1.66
           override: true
       - uses: actions-rs/cargo@v1
         with:

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use crate::escape::{UnescapedRef, UnscapedRoute};
+use crate::escape::{UnescapedRef, UnescapedRoute};
 use crate::tree::{denormalize_params, Node};
 
 use std::fmt;
@@ -49,7 +49,7 @@ impl std::error::Error for InsertError {}
 
 impl InsertError {
     pub(crate) fn conflict<T>(
-        route: &UnscapedRoute,
+        route: &UnescapedRoute,
         prefix: UnescapedRef<'_>,
         current: &Node<T>,
     ) -> Self {

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -1,17 +1,17 @@
-use std::ops::Range;
+use std::{fmt, ops::Range};
 
 /// An uescaped route that keeps track of the position of escaped characters ('{{' or '}}').
 ///
 /// Note that this type dereferences to `&[u8]`.
 #[derive(Clone, Default)]
-pub struct UnscapedRoute {
+pub struct UnescapedRoute {
     inner: Vec<u8>,
     escaped: Vec<usize>,
 }
 
-impl UnscapedRoute {
+impl UnescapedRoute {
     /// Unescapes escaped brackets ('{{' or '}}') in a route.
-    pub fn new(mut inner: Vec<u8>) -> UnscapedRoute {
+    pub fn new(mut inner: Vec<u8>) -> UnescapedRoute {
         let mut escaped = Vec::new();
         let mut i = 0;
 
@@ -26,11 +26,16 @@ impl UnscapedRoute {
             i += 1;
         }
 
-        UnscapedRoute { inner, escaped }
+        UnescapedRoute { inner, escaped }
+    }
+
+    /// Returns true if the character at the given index was escaped.
+    pub fn is_escaped(&self, i: usize) -> bool {
+        self.escaped.contains(&i)
     }
 
     /// Slices the route with `start..`.
-    pub fn slice_off(&self, start: usize) -> UnscapedRoute {
+    pub fn slice_off(&self, start: usize) -> UnescapedRoute {
         let mut escaped = Vec::new();
         for &i in &self.escaped {
             if i >= start {
@@ -38,18 +43,18 @@ impl UnscapedRoute {
             }
         }
 
-        UnscapedRoute {
+        UnescapedRoute {
             inner: self.inner[start..].to_owned(),
             escaped,
         }
     }
 
     /// Slices the route with `..end`.
-    pub fn slice_until(&self, end: usize) -> UnscapedRoute {
+    pub fn slice_until(&self, end: usize) -> UnescapedRoute {
         let mut escaped = self.escaped.clone();
         escaped.retain(|&i| i < end);
 
-        UnscapedRoute {
+        UnescapedRoute {
             inner: self.inner[..end].to_owned(),
             escaped,
         }
@@ -61,11 +66,14 @@ impl UnscapedRoute {
         range: Range<usize>,
         replace: Vec<u8>,
     ) -> impl Iterator<Item = u8> + '_ {
+        // ignore any escaped characters in the range being replaced
+        self.escaped.retain(|x| !range.contains(x));
+
         // update the escaped indices
-        let offset = (range.len() as isize) - (replace.len() as isize);
+        let offset = (replace.len() as isize) - (range.len() as isize);
         for i in &mut self.escaped {
-            if *i > range.start {
-                *i = (*i).checked_add_signed(offset).unwrap();
+            if *i > range.end {
+                *i = i.checked_add_signed(offset).unwrap();
             }
         }
 
@@ -73,7 +81,7 @@ impl UnscapedRoute {
     }
 
     /// Appends another route to the end of this one.
-    pub fn append(&mut self, other: &UnscapedRoute) {
+    pub fn append(&mut self, other: &UnescapedRoute) {
         for i in &other.escaped {
             self.escaped.push(self.inner.len() + i);
         }
@@ -83,6 +91,7 @@ impl UnscapedRoute {
 
     /// Truncates the route to the given length.
     pub fn truncate(&mut self, to: usize) {
+        self.escaped.retain(|&x| x < to);
         self.inner.truncate(to);
     }
 
@@ -106,11 +115,20 @@ impl UnscapedRoute {
     }
 }
 
-impl std::ops::Deref for UnscapedRoute {
+impl std::ops::Deref for UnescapedRoute {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
         &self.inner
+    }
+}
+
+impl fmt::Debug for UnescapedRoute {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UnescapedRoute")
+            .field("inner", &std::str::from_utf8(&self.inner))
+            .field("escaped", &self.escaped)
+            .finish()
     }
 }
 
@@ -119,20 +137,21 @@ impl std::ops::Deref for UnscapedRoute {
 pub struct UnescapedRef<'a> {
     pub inner: &'a [u8],
     escaped: &'a [usize],
-    offset: usize,
+    offset: isize,
 }
 
 impl<'a> UnescapedRef<'a> {
     /// Converts this reference into an owned route.
-    pub fn to_owned(self) -> UnscapedRoute {
+    pub fn to_owned(self) -> UnescapedRoute {
         let mut escaped = Vec::new();
         for &i in self.escaped {
-            if i + self.offset < self.inner.len() {
+            let i = i.wrapping_add_signed(-self.offset);
+            if i < self.inner.len() {
                 escaped.push(i);
             }
         }
 
-        UnscapedRoute {
+        UnescapedRoute {
             escaped,
             inner: self.inner.to_owned(),
         }
@@ -140,7 +159,7 @@ impl<'a> UnescapedRef<'a> {
 
     /// Returns true if the character at the given index was escaped.
     pub fn is_escaped(&self, i: usize) -> bool {
-        self.escaped.contains(&(i + self.offset))
+        self.escaped.contains(&(i.wrapping_add_signed(self.offset)))
     }
 
     /// Slices the route with `start..`.
@@ -148,7 +167,7 @@ impl<'a> UnescapedRef<'a> {
         UnescapedRef {
             inner: &self.inner[start..],
             escaped: self.escaped,
-            offset: self.offset + start,
+            offset: self.offset + (start as isize),
         }
     }
 
@@ -172,5 +191,15 @@ impl<'a> std::ops::Deref for UnescapedRef<'a> {
 
     fn deref(&self) -> &Self::Target {
         &self.inner
+    }
+}
+
+impl<'a> fmt::Debug for UnescapedRef<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UnescapedRef")
+            .field("inner", &std::str::from_utf8(&self.inner))
+            .field("escaped", &self.escaped)
+            .field("offset", &self.offset)
+            .finish()
     }
 }

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -1,0 +1,176 @@
+use std::ops::Range;
+
+/// An uescaped route that keeps track of the position of escaped characters ('{{' or '}}').
+///
+/// Note that this type dereferences to `&[u8]`.
+#[derive(Clone, Default)]
+pub struct UnscapedRoute {
+    inner: Vec<u8>,
+    escaped: Vec<usize>,
+}
+
+impl UnscapedRoute {
+    /// Unescapes escaped brackets ('{{' or '}}') in a route.
+    pub fn new(mut inner: Vec<u8>) -> UnscapedRoute {
+        let mut escaped = Vec::new();
+        let mut i = 0;
+
+        while let Some(&c) = inner.get(i) {
+            if (c == b'{' && inner.get(i + 1) == Some(&b'{'))
+                || (c == b'}' && inner.get(i + 1) == Some(&b'}'))
+            {
+                inner.remove(i);
+                escaped.push(i);
+            }
+
+            i += 1;
+        }
+
+        UnscapedRoute { inner, escaped }
+    }
+
+    /// Slices the route with `start..`.
+    pub fn slice_off(&self, start: usize) -> UnscapedRoute {
+        let mut escaped = Vec::new();
+        for &i in &self.escaped {
+            if i >= start {
+                escaped.push(i - start);
+            }
+        }
+
+        UnscapedRoute {
+            inner: self.inner[start..].to_owned(),
+            escaped,
+        }
+    }
+
+    /// Slices the route with `..end`.
+    pub fn slice_until(&self, end: usize) -> UnscapedRoute {
+        let mut escaped = self.escaped.clone();
+        escaped.retain(|&i| i < end);
+
+        UnscapedRoute {
+            inner: self.inner[..end].to_owned(),
+            escaped,
+        }
+    }
+
+    /// Replaces the characters in the given range.
+    pub fn splice(
+        &mut self,
+        range: Range<usize>,
+        replace: Vec<u8>,
+    ) -> impl Iterator<Item = u8> + '_ {
+        // update the escaped indices
+        let offset = (range.len() as isize) - (replace.len() as isize);
+        for i in &mut self.escaped {
+            if *i > range.start {
+                *i = i.checked_add_signed(offset).unwrap();
+            }
+        }
+
+        self.inner.splice(range, replace)
+    }
+
+    /// Appends another route to the end of this one.
+    pub fn append(&mut self, other: &UnscapedRoute) {
+        for i in &other.escaped {
+            self.escaped.push(self.inner.len() + i);
+        }
+
+        self.inner.extend_from_slice(&other.inner);
+    }
+
+    /// Truncates the route to the given length.
+    pub fn truncate(&mut self, to: usize) {
+        self.inner.truncate(to);
+    }
+
+    /// Returns a reference to this route.
+    pub fn as_ref(&self) -> UnescapedRef<'_> {
+        UnescapedRef {
+            inner: &self.inner,
+            escaped: &self.escaped,
+            offset: 0,
+        }
+    }
+
+    /// Returns a reference to the inner slice.
+    pub fn inner(&self) -> &[u8] {
+        &self.inner
+    }
+
+    /// Returns the inner slice.
+    pub fn into_inner(self) -> Vec<u8> {
+        self.inner
+    }
+}
+
+impl std::ops::Deref for UnscapedRoute {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+/// A reference to an `UnescapedRoute`.
+#[derive(Copy, Clone)]
+pub struct UnescapedRef<'a> {
+    pub inner: &'a [u8],
+    escaped: &'a [usize],
+    offset: usize,
+}
+
+impl<'a> UnescapedRef<'a> {
+    /// Converts this reference into an owned route.
+    pub fn to_owned(&self) -> UnscapedRoute {
+        let mut escaped = Vec::new();
+        for &i in self.escaped {
+            if i + self.offset < self.inner.len() {
+                escaped.push(i);
+            }
+        }
+
+        UnscapedRoute {
+            escaped,
+            inner: self.inner.to_owned(),
+        }
+    }
+
+    /// Returns true if the character at the given index was escaped.
+    pub fn is_escaped(&self, i: usize) -> bool {
+        self.escaped.contains(&(i + self.offset))
+    }
+
+    /// Slices the route with `start..`.
+    pub fn slice_off(&self, start: usize) -> UnescapedRef<'a> {
+        UnescapedRef {
+            inner: &self.inner[start..],
+            escaped: &self.escaped,
+            offset: self.offset + start,
+        }
+    }
+
+    /// Slices the route with `..end`.
+    pub fn slice_until(&self, end: usize) -> UnescapedRef<'a> {
+        UnescapedRef {
+            inner: &self.inner[..end],
+            escaped: &self.escaped,
+            offset: self.offset,
+        }
+    }
+
+    /// Returns a reference to the inner slice.
+    pub fn inner(&self) -> &[u8] {
+        &self.inner
+    }
+}
+
+impl<'a> std::ops::Deref for UnescapedRef<'a> {
+    type Target = &'a [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -65,7 +65,7 @@ impl UnscapedRoute {
         let offset = (range.len() as isize) - (replace.len() as isize);
         for i in &mut self.escaped {
             if *i > range.start {
-                *i = i.checked_add_signed(offset).unwrap();
+                *i = (*i).checked_add_signed(offset).unwrap();
             }
         }
 
@@ -124,7 +124,7 @@ pub struct UnescapedRef<'a> {
 
 impl<'a> UnescapedRef<'a> {
     /// Converts this reference into an owned route.
-    pub fn to_owned(&self) -> UnscapedRoute {
+    pub fn to_owned(self) -> UnscapedRoute {
         let mut escaped = Vec::new();
         for &i in self.escaped {
             if i + self.offset < self.inner.len() {
@@ -147,7 +147,7 @@ impl<'a> UnescapedRef<'a> {
     pub fn slice_off(&self, start: usize) -> UnescapedRef<'a> {
         UnescapedRef {
             inner: &self.inner[start..],
-            escaped: &self.escaped,
+            escaped: self.escaped,
             offset: self.offset + start,
         }
     }
@@ -156,14 +156,14 @@ impl<'a> UnescapedRef<'a> {
     pub fn slice_until(&self, end: usize) -> UnescapedRef<'a> {
         UnescapedRef {
             inner: &self.inner[..end],
-            escaped: &self.escaped,
+            escaped: self.escaped,
             offset: self.offset,
         }
     }
 
     /// Returns a reference to the inner slice.
     pub fn inner(&self) -> &[u8] {
-        &self.inner
+        self.inner
     }
 }
 

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -197,7 +197,7 @@ impl<'a> std::ops::Deref for UnescapedRef<'a> {
 impl<'a> fmt::Debug for UnescapedRef<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("UnescapedRef")
-            .field("inner", &std::str::from_utf8(&self.inner))
+            .field("inner", &std::str::from_utf8(self.inner))
             .field("escaped", &self.escaped)
             .field("offset", &self.offset)
             .finish()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,7 @@
 #![deny(rust_2018_idioms, clippy::all)]
 
 mod error;
+mod escape;
 mod params;
 mod router;
 mod tree;

--- a/tests/insert.rs
+++ b/tests/insert.rs
@@ -7,7 +7,7 @@ impl InsertTest {
         let mut router = Router::new();
         for (route, expected) in self.0 {
             let got = router.insert(route, route.to_owned());
-            assert_eq!(got, expected);
+            assert_eq!(got, expected, "{route}");
         }
     }
 }
@@ -218,6 +218,14 @@ fn invalid_param() {
         ("}}yy{{}}", Ok(())),
         ("}}yy{{}}{{}}y{{", Ok(())),
         ("}}yy{{}}{{}}y{{", Err(conflict("}yy{}{}y{"))),
+        ("/{{yy", Ok(())),
+        ("/{yy}", Ok(())),
+        ("/foo", Ok(())),
+        ("/foo/{{", Ok(())),
+        ("/foo/{{/{x}", Ok(())),
+        ("/foo/{ba{{r}", Ok(())),
+        ("/bar/{ba}}r}", Ok(())),
+        ("/xxx/{x{{}}y}", Ok(())),
     ])
     .run()
 }

--- a/tests/insert.rs
+++ b/tests/insert.rs
@@ -211,6 +211,13 @@ fn invalid_param() {
         ("x{y", Err(InsertError::InvalidParam)),
         ("x}", Err(InsertError::InvalidParam)),
         ("/{foo}s", Err(InsertError::InvalidParamSegment)),
+    ])
+    .run();
+}
+
+#[test]
+fn escaped_param() {
+    InsertTest(vec![
         ("{{", Ok(())),
         ("}}", Ok(())),
         ("xx}}", Ok(())),

--- a/tests/insert.rs
+++ b/tests/insert.rs
@@ -109,10 +109,10 @@ fn duplicates() {
 #[test]
 fn unnamed_param() {
     InsertTest(vec![
-        ("/{}", Err(InsertError::InvalidParamName)),
-        ("/user{}/", Err(InsertError::InvalidParamName)),
-        ("/cmd/{}/", Err(InsertError::InvalidParamName)),
-        ("/src/{*}", Err(InsertError::InvalidParamName)),
+        ("/{}", Err(InsertError::InvalidParam)),
+        ("/user{}/", Err(InsertError::InvalidParam)),
+        ("/cmd/{}/", Err(InsertError::InvalidParam)),
+        ("/src/{*}", Err(InsertError::InvalidParam)),
     ])
     .run()
 }
@@ -120,9 +120,9 @@ fn unnamed_param() {
 #[test]
 fn double_params() {
     InsertTest(vec![
-        ("/{foo}{bar}", Err(InsertError::InvalidParam)),
-        ("/{foo}{bar}/", Err(InsertError::InvalidParam)),
-        ("/{foo}{{*bar}/", Err(InsertError::InvalidParam)),
+        ("/{foo}{bar}", Err(InsertError::InvalidParamSegment)),
+        ("/{foo}{bar}/", Err(InsertError::InvalidParamSegment)),
+        ("/{foo}{{*bar}/", Err(InsertError::InvalidParamSegment)),
     ])
     .run()
 }
@@ -199,6 +199,25 @@ fn duplicate_conflict() {
         ("/hey/users", Ok(())),
         ("/hey/user", Ok(())),
         ("/hey/user", Err(conflict("/hey/user"))),
+    ])
+    .run()
+}
+
+#[test]
+fn invalid_param() {
+    InsertTest(vec![
+        ("{", Err(InsertError::InvalidParam)),
+        ("}", Err(InsertError::InvalidParam)),
+        ("x{y", Err(InsertError::InvalidParam)),
+        ("x}", Err(InsertError::InvalidParam)),
+        ("/{foo}s", Err(InsertError::InvalidParamSegment)),
+        ("{{", Ok(())),
+        ("}}", Ok(())),
+        ("xx}}", Ok(())),
+        ("}}yy", Ok(())),
+        ("}}yy{{}}", Ok(())),
+        ("}}yy{{}}{{}}y{{", Ok(())),
+        ("}}yy{{}}{{}}y{{", Err(conflict("}yy{}{}y{"))),
     ])
     .run()
 }


### PR DESCRIPTION
This is one of the last features I want to land as part of https://github.com/ibraheemdev/matchit/issues/35. It ended up being a lot more work than expected because of the way parameter normalizing/denormalizing works, but most of the new logic is contained within the `Unescaped` types during insertion, so search is unaffected.

This change also reworks `InsertError` to be more clear. `InsertError::InvalidParamSegment` now represents an error within a `/.../` segment (i.e. multiple parameters/unsupported suffix), while `InsertError::InvalidParam` represents any other parameter syntax related error. 