### PR TITLE
Reject Empty Route Parameters

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -562,6 +562,11 @@ impl<T> Node<T> {
                 NodeType::Param => {
                     // Check for more path segments.
                     let i = match path.iter().position(|&c| c == b'/') {
+                        // Double `//` implying an empty parameter, no match.
+                        Some(0) => {
+                            try_backtrack!();
+                            return Err(MatchError::NotFound);
+                        }
                         // Found another segment.
                         Some(i) => i,
                         // This is the last path segment.

--- a/tests/match.rs
+++ b/tests/match.rs
@@ -579,6 +579,19 @@ fn escaped() {
 }
 
 #[test]
+fn empty_param() {
+    MatchTest {
+        routes: vec!["/y/{foo}", "/x/{foo}/z", "/z/{*xx}"],
+        matches: vec![
+            ("/y/", "", Err(())),
+            ("/x//z", "", Err(())),
+            ("/z/", "", Err(())),
+        ],
+    }
+    .run();
+}
+
+#[test]
 fn basic() {
     MatchTest {
         routes: vec![


### PR DESCRIPTION
This fixes a bug where empty route parameters were accepted. For example, `/foo//bar` currently matches `/foo/{x}/bar`.