### PR TITLE
Avoid underflow when inserting route without leading slash

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -393,11 +393,11 @@ impl<T> Node<T> {
                 }
 
                 // Similarly, if we are inserting a longer prefix, and there is a route that leads to this
-                // parameter that includes a suffix, we have a prefix-suffix conflicts.
-                if common_remaining[common_prefix - 1] != b'/'
-                    && node.suffix_wild_child_in_segment()
-                {
-                    return Err(InsertError::conflict(&route, remaining, node));
+                // parameter that includes a suffix, we have a prefix-suffix conflict.
+                if let Some(i) = common_prefix.checked_sub(1) {
+                    if common_remaining[i] != b'/' && node.suffix_wild_child_in_segment() {
+                        return Err(InsertError::conflict(&route, remaining, node));
+                    }
                 }
             }
 

--- a/tests/insert.rs
+++ b/tests/insert.rs
@@ -16,10 +16,18 @@ fn conflict(with: &'static str) -> InsertError {
     InsertError::Conflict { with: with.into() }
 }
 
-// https://github.com/ibraheemdev/matchit/issues/84
+// Regression test for https://github.com/ibraheemdev/matchit/issues/84.
 #[test]
-fn root_prefix_issue() {
-    InsertTest(vec![("{foo}", Ok(())), ("{foo}suffix", Ok(()))]).run()
+fn missing_leading_slash_suffix() {
+    InsertTest(vec![("/{foo}", Ok(())), ("/{foo}suffix", Ok(()))]).run();
+    InsertTest(vec![("{foo}", Ok(())), ("{foo}suffix", Ok(()))]).run();
+}
+
+// Regression test for https://github.com/ibraheemdev/matchit/issues/82.
+#[test]
+fn missing_leading_slash_conflict() {
+    InsertTest(vec![("{foo}/", Ok(())), ("foo/", Ok(()))]).run();
+    InsertTest(vec![("foo/", Ok(())), ("{foo}/", Ok(()))]).run();
 }
 
 #[test]


### PR DESCRIPTION
Resolves https://github.com/ibraheemdev/matchit/issues/82.