### PR TITLE
Fix prefix-suffix conflict due to insertion order of trailing slashes

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -223,6 +223,11 @@ impl<T> Node<T> {
                         if *common == *child.prefix && remaining == *b"/" {
                             extra_trailing_slash = true;
                         }
+                    } else {
+                        let (common, remaining) = child.prefix.split_at(suffix.len());
+                        if *common == **suffix && remaining == *b"/" {
+                            extra_trailing_slash = true;
+                        }
                     }
                 }
 

--- a/tests/insert.rs
+++ b/tests/insert.rs
@@ -260,7 +260,7 @@ fn prefix_suffix_conflict() {
         ("/x19/f{a}o", Ok(())),
         ("/x19/f{a}o/{*path}", Ok(())),
         ("/x20/f{a}o/{*path}", Ok(())),
-        ("/x20/f{a}o", Err(conflict("/x20/f{a}o/{*path}"))),
+        ("/x20/f{a}o", Ok(())),
     ])
     .run()
 }

--- a/tests/insert.rs
+++ b/tests/insert.rs
@@ -257,6 +257,10 @@ fn prefix_suffix_conflict() {
         ("/x16/prefix{a}suffix", Ok(())),
         ("/x17/prefix{a}/z", Ok(())),
         ("/x18/prefix{a}/z", Ok(())),
+        ("/x19/f{a}o", Ok(())),
+        ("/x19/f{a}o/{*path}", Ok(())),
+        ("/x20/f{a}o/{*path}", Ok(())),
+        ("/x20/f{a}o", Err(conflict("/x20/f{a}o/{*path}"))),
     ])
     .run()
 }


### PR DESCRIPTION
This PR tries to solve the following failure,

```rust
#[test]
fn matchit_test1() {
    let mut router = Router::new();
    router.insert("/f{a}o", "picture").unwrap();
    router.insert("/f{a}o/{*path}", "regex").unwrap();
}

#[test]
fn matchit_test2() {
    let mut router = Router::new();
    router.insert("/f{a}o/{*path}", "regex").unwrap();
    router.insert("/f{a}o", "picture").unwrap();
}
```

`matchit_test1` can pass but `matchit_test2` fails with a conflict.

When inserting route parameters with static suffixes, `matchit` checked for conflicts between newly inserted suffixes and existing ones. It had an explicit exception to allow a new suffix that only differed by an extra trailing slash (e.g., `o/` vs existing `o`).

However, this check only evaluated one direction: if the *new* suffix was longer than the *existing* suffix. If the routes were inserted in the reverse order (e.g., `o/` inserted first, then `o` inserted second), the router incorrectly flagged them as a prefix-suffix conflict.

This commit makes the trailing slash check bidirectional by adding an `else` branch to verify if the *existing* suffix is the one with the extra trailing slash, resolving the insertion order dependency.

This PR is created with Gemini with the prompt of analyzing and fixing test case `matchit_test2`. 